### PR TITLE
adds CORS support for localhost (will need to change this to the domain ...

### DIFF
--- a/thresher_backend/settings.py
+++ b/thresher_backend/settings.py
@@ -75,7 +75,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'thresher',
-        'USER': 'zz',
+        'USER': 'dhass',
         'PASSWORD': '',
     }
 }

--- a/thresher_backend/settings.py
+++ b/thresher_backend/settings.py
@@ -46,18 +46,22 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'rest_framework',
     'thresher',
 )
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+CORS_ORIGIN_WHITELIST = ('localhost:4200')
 
 ROOT_URLCONF = 'thresher_backend.urls'
 
@@ -71,7 +75,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'thresher',
-        'USER': 'dhaas',
+        'USER': 'zz',
         'PASSWORD': '',
     }
 }


### PR DESCRIPTION
...wherever the frontend is hosted)

@thisisdhaas @FadyShoukry : please review

I used this library: https://github.com/ottoyiu/django-cors-headers/

We'll need to add something somewhere about running `pip install django-cors-headers` or `python setup.py install` (not sure which, this is the first time I've done anything with Django).