### PR TITLE
Fix article parser

### DIFF
--- a/load_data.py
+++ b/load_data.py
@@ -15,7 +15,7 @@ from django.core.exceptions import ValidationError
 from data.parse_document import parse_document
 from data.parse_schema import parse_schema
 from parse_schema import TopicsSchemaParser
-from thresher.models import Article, Topic
+from thresher.models import Article, SchemaTopic, Topic, HighlightGroup
 ANALYSIS_TYPES = {}
 HIGH_ID = 20000
 
@@ -23,11 +23,11 @@ def load_schema(schema):
     schema_name = schema['title']
     schema_parent = schema['parent']
     if schema_parent:
-        parent = Topic.objects.get(name=schema_parent)
+        parent = SchemaTopic.objects.get(name=schema_parent)
     else:
         parent = None
-    schema_obj = Topic(
-        parent = parent,
+    schema_obj = SchemaTopic(
+        parent=parent,
         name=schema_name,
         instructions=schema['instructions'],
         glossary=json.dumps(schema['glossary'])
@@ -37,7 +37,7 @@ def load_schema(schema):
     except ValidationError:
         # we've already loaded this schema, pull it into memory.
         print "Schema already exists. It will be overwritten"
-        curr_schema_obj = Topic.objects.get(name=schema_name)
+        curr_schema_obj = SchemaTopic.objects.get(name=schema_name)
         # We can't just delete the object because this will delete all TUAs associated with it.
         # Instead, we update the Analysis Type and delete all the topics associated with it.
         # When the id is set, django automatically knows to update instead of creating a new entry.
@@ -46,7 +46,7 @@ def load_schema(schema):
         schema_obj.save()
         # delete all topics associated with this Analysis Type
         # This will CASCADE DELETE all questions and answers as well
-        Topic.objects.filter(parent=schema_obj).delete()
+        SchemaTopic.objects.filter(parent=schema_obj).delete()
 
     ANALYSIS_TYPES[schema_name] = schema_obj
     print "loading schema:", schema_name
@@ -87,35 +87,35 @@ def load_article(article):
     article_obj.save()
 
     for tua_type, tuas in article['tuas'].iteritems():
+        offsets = []
+        try:
+            schema_topic_to_copy = SchemaTopic.objects.filter(name=tua_type)[0]
+            #analysis_type = (ANALYSIS_TYPES.get(tua_type) or
+            #                 Topic.objects.get(name=tua_type))
+        except IndexError:
+            # No analysis type loaded--create a dummy type.
+            schema_topic_to_copy = SchemaTopic.objects.create(
+                name=tua_type,
+                instructions='',
+                glossary='',
+            )
+            ANALYSIS_TYPES[tua_type] = schema_topic_to_copy
+            print("made a dummy topic")
+#           raise ValueError("No TUA type '" + tua_type +
+#                            "' registered. Have you loaded the schemas?")
         for tua_id, offset_list in tuas.iteritems():
-            try:
-                analysis_type = (ANALYSIS_TYPES.get(tua_type) or
-                                 Topic.objects.get(name=tua_type))
-            except Topic.DoesNotExist:
-                # No analysis type loaded--create a dummy type.
-                analysis_type = Topic.objects.create(
-                    name=tua_type,
-                    requires_processing=tua_type not in ['Useless', 'Future'],
-                    instructions='',
-                    glossary='',
-                    #topics='',
-                    question_dependencies='',
-                )
-                ANALYSIS_TYPES[tua_type] = analysis_type
-#                raise ValueError("No TUA type '" + tua_type +
-#                                 "' registered. Have you loaded the schemas?")
-            try:
-                tua_obj = Topic(
-                    analysis_type=analysis_type,
-                    article=article_obj,
-                    offsets=json.dumps(offset_list), # Probably need to process this more.
-                    tua_id=tua_id,
-                )
-                tua_obj.save()
-            except IntegrityError as e:
-                print "error!"
+            offsets.extend(offset_list)
 
-    print "loading article..."
+        highlight = HighlightGroup.objects.create(offsets=json.dumps(offsets))
+
+        try:
+            Topic.objects.create(schema=schema_topic_to_copy, 
+                                 article=article_obj, highlight=highlight)
+
+        except ValidationError as e:
+            print 'error on article #', new_id, 'tua #', tua_id, 'of', tua_type
+        
+    print 'loading article...'
 
 def load_schema_dir(dirpath):
     for schema_file in os.listdir(dirpath):

--- a/parse_schema.py
+++ b/parse_schema.py
@@ -27,8 +27,8 @@ class TopicsSchemaParser(object):
         else:
             self.schema_json = schema
         # ensure that the analysis_type is valid
-        if not isinstance(topic_obj, Topic):
-            raise ValueError("schema must be an instance of Topic model")
+        if not isinstance(topic_obj, SchemaTopic):
+            raise ValueError("schema must be an instance of SchemaTopic model")
         self.dep = dependencies
 
     def load_answers(self, answers, question):
@@ -73,7 +73,7 @@ class TopicsSchemaParser(object):
             # Set reference to parent
             topic_args['parent'] = self.topic_obj
             # Create the topic with the values in topic_args
-            topic = Topic.objects.create(**topic_args)
+            topic = SchemaTopic.objects.create(**topic_args)
             self.load_questions(questions, topic)
         self.load_next_question()
         self.load_dependencies()
@@ -85,7 +85,7 @@ class TopicsSchemaParser(object):
         signals the end. Also populates each mandatory question 
         with a default next question.
         """
-        topics = Topic.objects.filter(parent=self.topic_obj)
+        topics = SchemaTopic.objects.filter(parent=self.topic_obj)
         for topic in topics:
             questions = Question.objects.filter(topic=topic, 
                                                 contingency=False) \
@@ -112,7 +112,7 @@ class TopicsSchemaParser(object):
         """
         Loads dependencies into targeted answers.
         """
-        topics = Topic.objects.filter(parent=self.topic_obj)
+        topics = SchemaTopic.objects.filter(parent=self.topic_obj)
         for dep in self.dep:
             topic = topics.filter(order=dep.topic)
             question = Question.objects.filter(topic=topic, 

--- a/thresher/models.py
+++ b/thresher/models.py
@@ -49,7 +49,9 @@ class Article(models.Model):
             self.article_id, self.city_published, self.state_published,
             self.periodical)
 
-# Topics that are either parents of leaf topics, or leaf topics with questions.
+# SchemaTopics that are either parents of leaf topics, or leaf topics with questions.
+# Topics (defined further down) are "instances" of SchemaTopics, meaning that they
+# reference SchemaTopics' questions, answers, etc.
 class SchemaTopic(models.Model):
     # an id of its parent topic
     parent = models.ForeignKey("self", related_name="subtopics",
@@ -57,7 +59,7 @@ class SchemaTopic(models.Model):
 
     # The name of the topic
     name = models.TextField()
-    
+
     # The order of a leaf-topic
     order = models.IntegerField(null=True)
 
@@ -83,6 +85,7 @@ class SchemaTopic(models.Model):
             return "Topic %s in Parent %s" % (self.name, self.parent.name)
         return "Topic %s (no parent)" % (self.name)
 
+# A Topic that is bound to a specific article.
 class Topic(models.Model):
     # The schema topic we will be using
     schema = models.ForeignKey(SchemaTopic, related_name="article_topic")

--- a/thresher/models.py
+++ b/thresher/models.py
@@ -50,7 +50,7 @@ class Article(models.Model):
             self.periodical)
 
 # Topics that are either parents of leaf topics, or leaf topics with questions.
-class Topic(models.Model):
+class SchemaTopic(models.Model):
     # an id of its parent topic
     parent = models.ForeignKey("self", related_name="subtopics",
                                on_delete=models.CASCADE, null=True)
@@ -69,7 +69,7 @@ class Topic(models.Model):
     order = models.IntegerField(null=True)
 
     # Glossary related to the topic under analysis
-    glossary = models.TextField()                 # as a JSON map
+    glossary = models.TextField() # as a JSON map
 
     instructions = models.TextField()
 
@@ -90,13 +90,27 @@ class Topic(models.Model):
             return "Topic %s in Parent %s" % (self.name, self.parent.name)
         return "Topic %s (no parent)" % (self.name)
 
+class Topic(models.Model):
+    # The schema topic we will be using
+    schema = models.ForeignKey(SchemaTopic, related_name="article_topic")
+
+    # The referenced article
+    article = models.ForeignKey(Article, null=True)
+
+    # The relevant offsets in the article text.
+    # Stored as a JSON list of (start, end) pairs.
+    highlight = models.OneToOneField("HighlightGroup", null=True)
+    
+    def __unicode__(self):
+        return "Topic %s for Article %s" %(self.schema.name, self.article.article_id)
+
 # Question
 class Question(models.Model):
     # The question id the content is related to
     question_id = models.IntegerField()
 
     # The topic this question belongs to
-    topic = models.ForeignKey(Topic, related_name="related_questions", 
+    topic = models.ForeignKey(SchemaTopic, related_name="related_questions", 
                               on_delete=models.CASCADE)
 
     # The type of question (e.g. multiple choice, text box, ...)

--- a/thresher/models.py
+++ b/thresher/models.py
@@ -57,10 +57,7 @@ class SchemaTopic(models.Model):
 
     # The name of the topic
     name = models.TextField()
-
-    # The referenced article
-    article = models.ForeignKey(Article, null=True)
-
+    
     # The order of a leaf-topic
     order = models.IntegerField(null=True)
 

--- a/thresher/models.py
+++ b/thresher/models.py
@@ -76,7 +76,7 @@ class SchemaTopic(models.Model):
 
     def save(self, *args, **kwargs):
         self.validate_unique()
-        super(Topic, self).save(*args, **kwargs)
+        super(SchemaTopic, self).save(*args, **kwargs)
     
     class Meta:
         unique_together = ("parent", "order", "name")

--- a/thresher/models.py
+++ b/thresher/models.py
@@ -61,10 +61,6 @@ class SchemaTopic(models.Model):
     # The referenced article
     article = models.ForeignKey(Article, null=True)
 
-    # The relevant offsets in the article text.
-    # Stored as a JSON list of (start, end) pairs.
-    highlight = models.OneToOneField("HighlightGroup", null=True)
-
     # The order of a leaf-topic
     order = models.IntegerField(null=True)
 
@@ -74,7 +70,7 @@ class SchemaTopic(models.Model):
     instructions = models.TextField()
 
     def validate_unique(self, exclude=None):
-        qs = Topic.objects.filter(name=self.name)
+        qs = SchemaTopic.objects.filter(name=self.name)
         if qs.filter(parent=self.parent).exists() and self.id != qs[0].id:
             raise ValidationError('Subtopics need to be unique.')
 
@@ -95,11 +91,11 @@ class Topic(models.Model):
     schema = models.ForeignKey(SchemaTopic, related_name="article_topic")
 
     # The referenced article
-    article = models.ForeignKey(Article, null=True)
+    article = models.ForeignKey(Article)
 
     # The relevant offsets in the article text.
     # Stored as a JSON list of (start, end) pairs.
-    highlight = models.OneToOneField("HighlightGroup", null=True)
+    highlight = models.OneToOneField("HighlightGroup")
     
     def __unicode__(self):
         return "Topic %s for Article %s" %(self.schema.name, self.article.article_id)


### PR DESCRIPTION
This fixes the article parser. It also modifies our data model by splitting Topic into a SchemaTopic and Topic. SchemaTopics are loaded from the schema (think of a blueprint topic that someone wants to apply to multiple articles). Topics have ForeignKeys to SchemaTopics, and are bound to an Article + HighlightGroup. This is because each article that gets loaded needs its own instance of a Topic. We will need to modify the UserSubmittedAnswers in the future to fit this change.